### PR TITLE
Correct the dependency constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ json = ["reqwest/json"]
 default = ["derive", "json"]
 
 [dependencies]
-async-trait = "0"
+async-trait = "0.1"
 thiserror = "1.0"
 reqwest = "0.11"
 

--- a/retroqwest-derive/Cargo.toml
+++ b/retroqwest-derive/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.9"
-async-trait = "0"
+async-trait = "0.1"
 proc-macro2 = "1.0.29"
 thiserror = "1.0"
 


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.